### PR TITLE
Fix unavailable css href in readme after highlight.js latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ npm install react-highlight.js --save
 
 Choose a highlight.js theme and make sure it's included in your index file.
 ```html
-<link rel='stylesheet' href='https://highlightjs.org/static/demo/styles/railscasts.css'/>
+<link rel="stylesheet"
+      href="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.0.0/build/styles/default.min.css">
+<script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.0.0/build/highlight.min.js"></script>
 ```
 
 And then use react-highlight.js to display your text like so:


### PR DESCRIPTION
Hi, 

After the latest release of highlight.js on 2021-05-31, the css href is not available anymore. Fetching https://highlightjs.org/static/demo/styles/railscasts.css returns 404. Update the readme to reflect the new css path as described here in https://highlightjs.org/download/